### PR TITLE
Use Accept header for determining response format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: rust
 rust: nightly
-cache: cargo
 script:
-  - cargo build --verbose
-  - cargo test --verbose
+  # Build with all features to make sure they all compile.
+  - cargo build --verbose --all-features
+
+  # Test with combinations of all different features enabled to make sure they all work.
+  - cargo test --verbose --no-default-features --features "json"
+  - cargo test --verbose --no-default-features --features "msgpack"
+  - cargo test --verbose --all-features
+
+  # If we're building a tag, then publish to crates.io.
   - if [ ! -z "$TRAVIS_TAG" ]; then cargo publish --token $CRATES_TOKEN; fi
 env:
   global:

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -7,7 +7,12 @@ extern crate courier;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+
+#[cfg(feature = "json")]
 extern crate serde_json;
+
+#[cfg(feature = "msgpack")]
+extern crate rmp_serde;
 
 #[derive(Deserialize, FromData)]
 pub struct CustomRequest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,10 @@ pub fn derive_from_data(input: TokenStream) -> TokenStream {
                 let reader = data.open().take(limit);
                 return match ::rmp_serde::decode::from_read(reader) {
                     Ok(value) => Outcome::Success(value),
-                    Err(_error) => Outcome::Failure((Status::InternalServerError, Failure(Status::InternalServerError))),
+                    Err(_) => Outcome::Failure((
+                        Status::InternalServerError,
+                        Failure(Status::InternalServerError),
+                    )),
                 };
             }
         }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,10 @@
 //! # #[macro_use] extern crate courier;
 //! # extern crate serde;
 //! # #[macro_use] extern crate serde_derive;
+//! # #[cfg(feature = "json")]
 //! # extern crate serde_json;
+//! # #[cfg(feature = "msgpack")]
+//! # extern crate rmp_serde;
 //! #[derive(Deserialize, FromData)]
 //! pub struct CustomRequest {
 //!     // Some members go here.
@@ -79,7 +82,7 @@
 //!
 //! And then add `rmp-serde` to your project root:
 //!
-//! ```rust
+//! ```rust,ignore
 //! #[macro_use]
 //! extern crate courier;
 //!
@@ -119,7 +122,10 @@
 //! # #[macro_use] extern crate courier;
 //! # extern crate serde;
 //! # #[macro_use] extern crate serde_derive;
+//! # #[cfg(feature = "json")]
 //! # extern crate serde_json;
+//! # #[cfg(feature = "msgpack")]
+//! # extern crate rmp_serde;
 //! #
 //! # #[derive(Deserialize, FromData)]
 //! # pub struct CustomRequest {
@@ -147,7 +153,10 @@
 //! # #[macro_use] extern crate courier;
 //! # extern crate serde;
 //! # #[macro_use] extern crate serde_derive;
+//! # #[cfg(feature = "json")]
 //! # extern crate serde_json;
+//! # #[cfg(feature = "msgpack")]
+//! # extern crate rmp_serde;
 //! #
 //! # #[derive(Deserialize, FromData)]
 //! # pub struct CustomRequest {
@@ -199,8 +208,49 @@ pub fn derive_from_data(input: TokenStream) -> TokenStream {
     let derive_input = syn::parse_derive_input(&input.to_string()).unwrap();
     let ident = derive_input.ident;
 
-    let json = from_data_json();
-    let msgpack = from_data_msgpack();
+    let json = if cfg!(feature = "json") {
+        quote! {{
+            let is_json = request.content_type().map(|ct| ct.is_json()).unwrap_or(false);
+            if is_json {
+                let limit = request.limits().get("json").unwrap_or(u64::MAX);
+                let reader = data.open().take(limit);
+                return match ::serde_json::from_reader(reader) {
+                    Ok(value) => Outcome::Success(value),
+                    Err(_error) => Outcome::Failure((Status::InternalServerError, Failure(Status::InternalServerError))),
+                };
+            }
+        }}
+    } else {
+        Tokens::new()
+    };
+
+
+    let msgpack = if cfg!(feature = "msgpack") {
+        quote! {{
+            // Accepted content types are:
+            //
+            // - `application/msgpack`
+            // - `application/x-msgpack`
+            // - `bin/msgpack`
+            // - `bin/x-msgpack`
+            let is_msgpack = request.content_type()
+                .map(|content_type| {
+                    (content_type.top() == "application" || content_type.top() == "bin") &&
+                    (content_type.sub() == "msgpack" || content_type.sub() == "x-msgpack")
+                })
+                .unwrap_or(false);
+            if is_msgpack {
+                let limit = request.limits().get("msgpack").unwrap_or(u64::MAX);
+                let reader = data.open().take(limit);
+                return match ::rmp_serde::decode::from_read(reader) {
+                    Ok(value) => Outcome::Success(value),
+                    Err(_error) => Outcome::Failure((Status::InternalServerError, Failure(Status::InternalServerError))),
+                };
+            }
+        }}
+    } else {
+        Tokens::new()
+    };
 
     let gen = quote! {
         impl ::rocket::data::FromData for #ident {
@@ -231,67 +281,71 @@ pub fn derive_responder(input: TokenStream) -> TokenStream {
     let derive_input = syn::parse_derive_input(&input.to_string()).unwrap();
     let ident = derive_input.ident;
 
+    let json = if cfg!(feature = "json") {
+        quote! {{
+            let accept_json = request.accept()
+                .map(|accept| accept.preferred().is_json())
+                .unwrap_or(false);
+            if accept_json {
+                return ::serde_json::to_string(&self).map(|string| {
+                    ::rocket::response::content::Json(string).respond_to(request).unwrap()
+                }).map_err(|_error| {
+                    ::rocket::http::Status::InternalServerError
+                });
+            }
+        }}
+    } else {
+        Tokens::new()
+    };
+
+    let msgpack = if cfg!(feature = "msgpack") {
+        quote! {{
+            // Accepted content types are:
+            //
+            // - `application/msgpack`
+            // - `application/x-msgpack`
+            // - `bin/msgpack`
+            // - `bin/x-msgpack`
+            let accept_msgpack = request.accept()
+                .map(|accept| accept.preferred())
+                .map(|content_type| {
+                    (content_type.top() == "application" || content_type.top() == "bin") &&
+                    (content_type.sub() == "msgpack" || content_type.sub() == "x-msgpack")
+                })
+                .unwrap_or(false);
+            if accept_msgpack {
+                return rmp_serde::to_vec(&self)
+                    .map_err(|_| Status::InternalServerError)
+                    .and_then(|buf| {
+                        Response::build()
+                            .sized_body(::std::io::Cursor::new(buf))
+                            .ok()
+                    });
+            }
+        }}
+    } else {
+        Tokens::new()
+    };
+
     let gen = quote! {
         /// Serializes the wrapped value into JSON. Returns a response with Content-Type
         /// JSON and a fixed-size body with the serialized value. If serialization
         /// fails, an `Err` of `Status::InternalServerError` is returned.
         impl ::rocket::response::Responder<'static> for #ident {
             fn respond_to(self, request: &::rocket::Request) -> ::rocket::response::Result<'static> {
-                // TODO: Serialize to different formats based on the content type of the request.
-                ::serde_json::to_string(&self).map(|string| {
-                    ::rocket::response::content::Json(string).respond_to(request).unwrap()
-                }).map_err(|_error| {
-                    ::rocket::http::Status::InternalServerError
-                })
+                use rocket::http::Status;
+                use rocket::response::Response;
+
+                #json
+
+                #msgpack
+
+                // If none of the known formats are specified in the `Accept` header, then return
+                // a 406 Not Acceptable error to indicate that the resource couldn't be returned
+                // in an acceptable format.
+                Err(Status::NotAcceptable)
             }
         }
     };
     gen.parse().unwrap()
-}
-
-fn from_data_json() -> Tokens {
-    if cfg!(feature = "json") {
-        quote! {{
-            let is_json = request.content_type().map(|ct| ct.is_json()).unwrap_or(false);
-            if is_json {
-                let limit = request.limits().get("json").unwrap_or(u64::MAX);
-                let reader = data.open().take(limit);
-                return match ::serde_json::from_reader(reader) {
-                    Ok(value) => Outcome::Success(value),
-                    Err(_error) => Outcome::Failure((Status::InternalServerError, Failure(Status::InternalServerError))),
-                };
-            }
-        }}
-    } else {
-        Tokens::new()
-    }
-}
-
-fn from_data_msgpack() -> Tokens {
-    if cfg!(feature = "msgpack") {
-        quote! {{
-            // Accepted content types are:
-            //
-            // - `application/msgpack`
-            // - `application/x-msgpack`,
-            // - `bin/msgpack`
-            // - `bin/x-msgpack`.
-            let is_msgpack = request.content_type()
-                .map(|content_type| {
-                    (content_type.top() == "application" || content_type.top() == "bin") &&
-                    (content_type.sub() == "msgpack" || content_type.sub() == "x-msgpack")
-                })
-                .unwrap_or(false);
-            if is_msgpack {
-                let limit = request.limits().get("msgpack").unwrap_or(u64::MAX);
-                let reader = data.open().take(limit);
-                return match ::rmp_serde::decode::from_read(reader) {
-                    Ok(value) => Outcome::Success(value),
-                    Err(_error) => Outcome::Failure((Status::InternalServerError, Failure(Status::InternalServerError))),
-                };
-            }
-        }}
-    } else {
-        Tokens::new()
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,9 +318,9 @@ pub fn derive_responder(input: TokenStream) -> TokenStream {
                 .unwrap_or(false);
             if accept_msgpack {
                 return rmp_serde::to_vec(&self)
-                    .map_err(|_| Status::InternalServerError)
+                    .map_err(|_| ::rocket::http::Status::InternalServerError)
                     .and_then(|buf| {
-                        Response::build()
+                        ::rocket::response::Response::build()
                             .sized_body(::std::io::Cursor::new(buf))
                             .ok()
                     });
@@ -336,9 +336,6 @@ pub fn derive_responder(input: TokenStream) -> TokenStream {
         /// fails, an `Err` of `Status::InternalServerError` is returned.
         impl ::rocket::response::Responder<'static> for #ident {
             fn respond_to(self, request: &::rocket::Request) -> ::rocket::response::Result<'static> {
-                use rocket::http::Status;
-                use rocket::response::Response;
-
                 #json
 
                 #msgpack
@@ -346,7 +343,7 @@ pub fn derive_responder(input: TokenStream) -> TokenStream {
                 // If none of the known formats are specified in the `Accept` header, then return
                 // a 406 Not Acceptable error to indicate that the resource couldn't be returned
                 // in an acceptable format.
-                Err(Status::NotAcceptable)
+                Err(::rocket::http::Status::NotAcceptable)
             }
         }
     };

--- a/tests/msgpack.rs
+++ b/tests/msgpack.rs
@@ -15,7 +15,7 @@ extern crate serde_derive;
 extern crate serde_json;
 
 use rocket::local::Client;
-use rocket::http::{Accept, ContentType, Status};
+use rocket::http::{Accept, ContentType, MediaType, Status};
 
 #[derive(Debug, Serialize, Deserialize, FromData, PartialEq, Eq)]
 pub struct CustomRequest {
@@ -32,6 +32,7 @@ pub struct CustomResponse {
 fn request_response() {
     #[post("/test", data = "<request>")]
     fn handler(request: CustomRequest) -> CustomResponse {
+        println!("Received request: {:?}", request);
         assert_eq!(CustomRequest { foo: "Foo".into(), bar: 10 }, request);
         CustomResponse { baz: request.bar }
     }
@@ -39,13 +40,13 @@ fn request_response() {
     let rocket = rocket::ignite().mount("/", routes![handler]);
     let client = Client::new(rocket).unwrap();
     let mut response = client.post("/test")
-        .body(serde_json::to_string(&CustomRequest { foo: "Foo".into(), bar: 10 }).unwrap())
-        .header(ContentType::JSON)
-        .header(Accept::JSON)
+        .body(rmp_serde::to_vec(&CustomRequest { foo: "Foo".into(), bar: 10 }).unwrap())
+        .header(ContentType::new("application", "msgpack"))
+        .header(Accept::new(&[MediaType::new("application", "msgpack").into()]))
         .dispatch();
     assert_eq!(Status::Ok, response.status());
-    let body = response.body_string().expect("No body in test response");
-    let response = serde_json::from_str(&*body).expect("Failed to parse response JSON");
+    let body = response.body_bytes().expect("No body in test response");
+    let response = rmp_serde::from_slice(&*body).expect("Failed to parse response JSON");
     assert_eq!(CustomResponse { baz: 10 }, response);
 }
 
@@ -60,8 +61,8 @@ fn not_acceptable() {
     let rocket = rocket::ignite().mount("/", routes![handler]);
     let client = Client::new(rocket).unwrap();
     let response = client.post("/test")
-        .body(serde_json::to_string(&CustomRequest { foo: "Foo".into(), bar: 10 }).unwrap())
-        .header(ContentType::JSON)
+        .body(rmp_serde::to_vec(&CustomRequest { foo: "Foo".into(), bar: 10 }).unwrap())
+        .header(ContentType::new("application", "msgpack"))
         .dispatch();
     assert_eq!(Status::NotAcceptable, response.status());
 }

--- a/tests/msgpack.rs
+++ b/tests/msgpack.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "json")]
+#![cfg(feature = "msgpack")]
 
 #![feature(plugin)]
 #![plugin(rocket_codegen)]
@@ -6,11 +6,12 @@
 extern crate rocket;
 #[macro_use]
 extern crate courier;
-#[cfg(feature = "msgpack")]
 extern crate rmp_serde;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+
+#[cfg(feature = "json")]
 extern crate serde_json;
 
 use rocket::local::Client;


### PR DESCRIPTION
The initial release of courier had a few issues:

* The generated `Responder` impl checked the `ContentType` header instead of the `Accept` header to determine which format to use. This was caused my misunderstanding of HTTP content negotiation.
* The generated `Responder` impl never returned MessagePack data, even when the `msgpack` feature was enabled. Completely an oversight on my part.

This PR resolves both issues:

* The `Responder` impl now checks the preferred content type specified in the `Accept` header to determine which format to use. This isn't the optimal solution, but it's a reasonable first pass.
* I've added unit tests to test that MessagePack data is accepted properly and the response is sent correctly as MessagePack data.
* I've updated the Travis build script to test different combinations of the `json` and `msgpack` features being enabled and disabled. As more supported formats are added, the script should be updated to test all possible combinations.